### PR TITLE
Update featured data contributing guidelines

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -178,41 +178,62 @@ ADD CONTENT HERE
 ## Create a Featured Data article
 
 To create a new featured data article:
-1. Copy the template below and paste into a new file in the `/templates/featured` directory.
-2. The file name should follow `featured-YYYYMMDD.XX.md`, where `YYYYMMDD` is the date the article was created, `XX` is the news article created on that date (use `00` if only one article was published on that day).
-3. Update the TITLE, DATE, AUTHOR, and CONTENT placeholders.
-4. Images should be added to the `/static/images/featured_data` directory and referenced from there.
-5. Commit changes and push to the content-x GitHub.
-6. Notify the website team that new content has been added and they will integrate your work into the website.
+1. Create a markdown file for the new featured data article in the `/templates/featured` directory. Name it following the pattern `featured-ID.md` where `ID` uniquely identifies the article.
+2. Copy the template below and paste into the new file.
+3. Update the `TITLE`, `DATE`, `AUTHOR`, `CITATION`, and `CONTENT` placeholders. Note, the final date of publication will be added later. Do not add a date here or else the article will be listed in the featured data article index.
+4. Compress article images using a service like [tinypng.com](https://tinypng.com/). Add images to the `/static/images/featured_data` directory and reference from within display type HTML blocks (`gallery` and/or `figure_featured`; see below). Replicate these HTML blocks as needed.
+5. Commit changes to the development branch and push to the content-x GitHub. Notify the website team that new content has been added, they will integrate your work into the development side of the web-x server (i.e. web-d) and will send you a link to the article proof. Note, the article will only be referencable from the link since it is unattached to other website pages. This keeps the WIP hidden from public view. 
+6. Send the article author a proof for review and comment. Apply any requested changes and repeat step 5 above.
+7. When ready to publish, update the file name to follow the pattern `featured-YYYYMMDD.XX.md`, where `YYYYMMDD` is the date the article was created, `XX` is the news article created on that date (use `00` if only one article was published on that day). Repeat step 5 above.
+8. Notify article authors of the publication.
 
 ```
 # Featured Data
 
-## ADD TITLE HERE
+## TITLE
 
-ADD DATE HERE (e.g. March 1, 2021)
+DATE (e.g. March 1, 2021)
 
-ADD ARTICLE AUTHOR HERE
+AUTHOR
 
 ### Citation
 
-ADD CITATION HERE
+CITATION
 
 ### Description
 
-ADD CONTENT HERE
+CONTENT
 
 <!-- Images used in articles follow the HTML format below. Adjust the "width" parameter to resize. 
 Identify the primary image to use with the featured data display on web-x home page and on the featured 
-data grid page by adding an id="pickme" parameter to the HTML, if not specified, the first image of the 
-page will be used.-->
+data grid page by adding an id="pickme" parameter to the HTML, if not specified, the first image of the page will be used. Note, there are two ways to display images.-->
 
-<div class="figure_featured" style="width: 25%;">
-    <figure>
-       <img id="pickme" src="/static/images/featured_data/MYIMAGE.png" alt="ADD DESCRIPTION OF IMAGE"/>
-       <figcaption class="figure-caption">ADD CAPTION HERE</figcaption>
-    </figure>
+<div class="figure_featured" style="width: 75%;">
+   <figure>
+     <a href="/static/images/featured_data/FILE.EXT">
+       <img src="/static/images/featured_data/FILE.EXT" alt="ADD DESCRIPTION OF IMAGE"/>
+     </a>
+     <figcaption class="figure-caption">ADD CAPTION HERE</figcaption>
+   </figure>
 </div>
+
+<div>
+  <div class="gallery">
+    <a href="/static/images/featured_data/IMAGE.EXT">
+      <img src="/static/images/featured_data/IMAGE.EXT" alt="ADD DESCRIPTION OF IMAGE">
+    </a>
+    <a href="/static/images/featured_data/IMAGE.EXT">
+      <img src="/static/images/featured_data/IMAGE.EXT" alt="ADD DESCRIPTION OF IMAGE">
+    </a>
+    <a href="/static/images/featured_data/IMAGE.EXT">
+      <img src="/static/images/featured_data/IMAGE.EXT" alt="ADD DESCRIPTION OF IMAGE">
+    </a>
+  </div>
+  <div>
+    <p class="figure-caption" style="color: #6c757d">ADD CAPTION HERE FOR ALL IMAGES REFERENCED ABOVE</p>
+  </div>
+</div>
+
 
 #### Data sources for the database include
 

--- a/templates/featured/featured-dwr.md
+++ b/templates/featured/featured-dwr.md
@@ -1,0 +1,51 @@
+# Featured Data
+
+## Data packages published by EDI's 2022 Summer Fellows
+
+September 1, 2022
+
+Susanne Grossman-Clarke
+
+
+### Citation
+
+Garretson, A.C., J. Disney, M.A. Maniscalco, A. Farrell, C. Bailey, J. Matt, U. Arora, M. Armstrong, S. Pratt, N. Dorn, and F. Durand. 2022. Harmful algal bloom monitoring data near Frenchman Bay from 2004-2022 ver 3. Environmental Data Initiative. [https://doi.org/10.6073/pasta/11e3a827670392047a08155cb6128a76 (Accessed 2022-08-31)](https://doi.org/10.6073/pasta/11e3a827670392047a08155cb6128a76).
+
+### Description
+
+We awarded 14 fellowships for our fifth ecological data management training program (20 June - 19 August 2022). The Fellows received training in ecological data management during a three-day online data publishing workshop and gained hands-on experience through participation in data preparation and publishing with scientists and information managers from specific host research projects, spanning diverse ecosystems across the country, from Maine’s Mount Desert Island to Puerto Rico’s Luquillo Mountains to the Palmyra Atoll in the central Pacific. Our Fellows published a number of data packages.
+
+<div class="figure_featured" style="width: 60%;">
+    <figure>
+       <img src="/static/images/featured_data/frenchman_bay_nps_small.jpg" alt="Frenchman Bay Maine"/>
+       <figcaption class="figure-caption">View from Cadillac Mountain of Frenchman Bay and the Porcupine Islands. Harmful algal bloom data were published by Michael Maniscalo, Fellow with <a href="https://mdibl.org/">Mount Desert Island Biological Laboratory</a> (photo credit: <a href="https://www.nps.gov/media/photo/view.htm?id=00d5bd2d-0905-4b46-96f9-791b6377f51c">NPS Photo/Kent Miller</a>).</figcaption>
+    </figure>
+</div>
+
+The projects included LTER and Forest Services sites (i.e. [Jornada Basin LTER](https://lter.jornada.nmsu.edu/) and [Marcell Experimental Forest](https://www.nrs.fs.fed.us/ef/marcell/)), citizen science projects such as [Journey North](https://journeynorth.org/) and the [Charleston Community Research to Action Board (CCRAB)](https://www.facebook.com/CCRABSC/), serving environmental justice communities in Charleston, South Carolina. For more information on this year's host projects, visit the website on the [2022 Fellowship Program](/support/fellowship-2022). More data packages will be completed soon and added to the list below.
+
+### References
+
+Garretson, A.C., J. Disney, M.A. Maniscalco, A. Farrell, C. Bailey, J. Matt, U. Arora, M. Armstrong, S. Pratt, N. Dorn, and F. Durand. 2022. Harmful algal bloom monitoring data near Frenchman Bay from 2004-2022 ver 3. Environmental Data Initiative. [https://doi.org/10.6073/pasta/11e3a827670392047a08155cb6128a76 (Accessed 2022-08-31)](https://doi.org/10.6073/pasta/11e3a827670392047a08155cb6128a76).
+
+Maldonado-Benítez, N., A.C. Mariani-Rios, and A. Ramírez. 2022. Odonata Assemblage in Metropolitan Area of Puerto Rico (2018-2019, Wet and Dry Season) ver 1. Environmental Data Initiative. [https://doi.org/10.6073/pasta/6acdab665dc5e8df4b24aa29782e3647 (Accessed 2022-09-01)](https://doi.org/10.6073/pasta/6acdab665dc5e8df4b24aa29782e3647).
+
+Mariani-Rios, A.C., N. Maldonado-Benítez, and A. Ramírez. 2022. Survey of Odonata Abundance in Two Streams at El Yunque Rainforest (2018-2019) ver 1. Environmental Data Initiative. [https://doi.org/10.6073/pasta/1f278a2cd2496c3b0747d4518bc8ab7d (Accessed 2022-08-31)](https://doi.org/10.6073/pasta/1f278a2cd2496c3b0747d4518bc8ab7d).
+
+Malone, S.L. and S.F. Oberbauer. 2022. Chamber measurements of carbon dioxide (CO2) and methane (CH4) in Everglades following Hurricane Irma: 2017 - 2019 ver 2. Environmental Data Initiative. [https://doi.org/10.6073/pasta/61705af69ee88cf47baf4aed2822d9af (Accessed 2022-08-31)](https://doi.org/10.6073/pasta/61705af69ee88cf47baf4aed2822d9af).
+
+Sheehan, N. and M. Abarca. 2022. Journey North - Gray Whale observations by volunteer community scientists across the Eastern Pacific Ocean (1997-2020) ver 3. Environmental Data Initiative. [https://doi.org/10.6073/pasta/9764f8f6df4cd4a8cdf9440a6483cdc0 (Accessed 2022-08-31)](https://doi.org/10.6073/pasta/9764f8f6df4cd4a8cdf9440a6483cdc0).
+
+Sheehan, N. and M. Abarca. 2022. Journey North - Common Loon and Ice-Out observations by volunteer community scientists across North America (1997-2020) ver 2. Environmental Data Initiative. [https://doi.org/10.6073/pasta/9b8eee58e19deed5d5e6fcbbf2318adf (Accessed 2022-08-31)](https://doi.org/10.6073/pasta/9b8eee58e19deed5d5e6fcbbf2318adf).
+
+Sheehan, N. and M. Abarca. 2022. Journey North - Tulip observations by volunteer community scientists across North America (1996-2020) ver 1. Environmental Data Initiative. [https://doi.org/10.6073/pasta/3c94a675eb2e870ed47d0c0d53df7f0f (Accessed 2022-08-31)](https://doi.org/10.6073/pasta/3c94a675eb2e870ed47d0c0d53df7f0f).
+
+Sheehan, N. and M. Abarca. 2022. Journey North - Barn Swallow observations by volunteer community scientists across Central and North America (2000-2020) ver 1. Environmental Data Initiative. [https://doi.org/10.6073/pasta/8fe04755e8895f2a0100bc22402440db (Accessed 2022-08-31)](https://doi.org/10.6073/pasta/8fe04755e8895f2a0100bc22402440db).
+
+Sheehan, N. and M. Abarca. 2022. Journey North - Red-winged blackbird observations by volunteer community scientists across Central and North America (1999-2020) ver 1. Environmental Data Initiative. [https://doi.org/10.6073/pasta/b6fe30b4a8b9a761cd809469ef6356c8 (Accessed 2022-08-31)](https://doi.org/10.6073/pasta/b6fe30b4a8b9a761cd809469ef6356c8).
+
+Sheehan, N. and M. Abarca. 2022. Journey North - American Robin observations by volunteer community scientists across Central and North America (1996-2020) ver 1. Environmental Data Initiative. [https://doi.org/10.6073/pasta/935978d401d9b947865a9744db90f417 (Accessed 2022-08-31)](https://doi.org/10.6073/pasta/935978d401d9b947865a9744db90f417).
+
+Sheehan, N. and M. Abarca. 2022. Journey North - Oriole observations by volunteer community scientists across Central and North America (1997-2020) ver 2. Environmental Data Initiative. [https://doi.org/10.6073/pasta/2844e3353c633bcf4043ecb0955196b0 (Accessed 2022-08-31)](https://doi.org/10.6073/pasta/2844e3353c633bcf4043ecb0955196b0).
+
+### [All featured data contributions](/templates/featured/featured-grid)


### PR DESCRIPTION
These guidelines leverage an existing behavior in the web-x codebase that keeps articles hidden when the article file name deviates from the expected pattern YYYYMMDD-XX.md, which allows articles to be viewable by authors as hidden proofs.

Also added here is the image gallery implementation currently under review at web-x. So, so this commit may need to be updated depending on the outcome of that conversation.